### PR TITLE
Fixed double checking bug

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -553,6 +553,21 @@ async function handleExternalAction(sendResponse, func, args){
 
 
 /*---Main Startup---*/
+function initExtension(){
+  if (typeof syncEnrollmentInterval == 'undefined'){
+    syncEnrollment();
+    let syncEnrollmentInterval = setInterval(syncEnrollment, 30000);
+  }
+  if (typeof syncEnrollmentInterval == 'undefined'){
+    let setBlockedSitesInterval = setBlockedSitesLoop();
+  }
+  if (typeof permissionsCheckInterval == 'undefined'){
+    checkPermissions();
+    let permissionsCheckInterval = setInterval(checkPermissions, 1000);
+  }
+  return logData("info","EXTENSION INITILISATION COMPLETE");
+}
+
 if (typeof window == 'undefined') { //The javascript equivilant of `if __name__ == '__main__':` in python
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request === 'getBlockedSites') {
@@ -579,30 +594,6 @@ if (typeof window == 'undefined') { //The javascript equivilant of `if __name__ 
     }
   });
 
-  chrome.runtime.onStartup.addListener(function() {
-    if (typeof syncEnrollmentInterval == 'undefined'){
-      syncEnrollment();
-      let syncEnrollmentInterval = setInterval(syncEnrollment, 30000);
-    }
-    if (typeof syncEnrollmentInterval == 'undefined'){
-      let setBlockedSitesInterval = setBlockedSitesLoop();
-    }
-    if (typeof permissionsCheckInterval == 'undefined'){
-      checkPermissions();
-      let permissionsCheckInterval = setInterval(checkPermissions, 1000);
-    }
-  });
-
-  if (typeof syncEnrollmentInterval == 'undefined'){
-    syncEnrollment();
-    let syncEnrollmentInterval = setInterval(syncEnrollment, 30000);
-  }
-  if (typeof syncEnrollmentInterval == 'undefined'){
-    let setBlockedSitesInterval = setBlockedSitesLoop();
-  }
-  if (typeof permissionsCheckInterval == 'undefined'){
-    checkPermissions();
-    let permissionsCheckInterval = setInterval(checkPermissions, 1000);
-  }
-  logData("info","INITILISATION COMPLETE");//This is async function but I can't put `await` here.
+  chrome.runtime.onStartup.addListener(initExtension);
+  chrome.runtime.onInstalled.addListener(initExtension);
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Ignite DMA",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "AzlanCoding",
   "description": "A Device Manager Application (DMA) for students under MOE",
   "homepage_url": "https://ignitedma.mooo.com/",

--- a/server/assets/service/update.xml
+++ b/server/assets/service/update.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
     <app appid='clhnfaboginbheghbebffggbdnijjika'>
-        <updatecheck codebase='https://ignitedma.mooo.com/assets/service/chrome_extension/v1.1.0.crx' version='1.1.0' />
+        <updatecheck codebase='https://ignitedma.mooo.com/assets/service/chrome_extension/v1.1.1.crx' version='1.1.1' />
 		</app>
 </gupdate>


### PR DESCRIPTION
Fixed bug of which `syncEnrollment` , `setBlockedSitesLoop` and  `checkPermissions` called twice after reboot.